### PR TITLE
Modernize the ixo address generation function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ Cosmos.prototype.getIxoAddress = function(mnemonic, checkSum = true) {
 		if (!bip39.validateMnemonic(mnemonic)) throw new Error("mnemonic phrases have invalid checksums");
 	}
 	const ixoDid = Cosmos.prototype.getIxoDid(mnemonic)
-	const verifyKey = crypto.createHash('sha256').update(base58.decode(ixoDid.verifyKey)).digest('bytes').slice(0, 20)
+	const verifyKey = crypto.createHash('sha256').update(base58.decode(ixoDid.verifyKey)).digest().slice(0, 20)
 	return bech32.encode(this.bech32MainPrefix, bech32.toWords(verifyKey));
 }
 


### PR DESCRIPTION
Apparently the "bytes" value for the crypto's digest function's
"encoding" argument is deprecated. It looks like it was used to
make the function output a Buffer data type, but the digest
function is currently behaving the same way even if we don't
specify an encoding.

This is no big deal in Node environments as it seems like this
legacy argument is still supported, but it breaks when we use the
React Native shim for crypto. One can say that it is susceptible
of breaking in similar scenarios.

Removing this parameter seems to be safe, in my experiments it
worked in both Node and the shimmed RN environments.

References:
https://github.com/mvayngrib/react-native-crypto
https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding
https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings